### PR TITLE
Add interview list

### DIFF
--- a/content/community/interviews.md
+++ b/content/community/interviews.md
@@ -1,0 +1,37 @@
+# Interviews
+
+## Developers
+
+### Finished
+
+- [x] Dan Schult (NetworkX)
+- [x] Alex de Siqueira (scikit-image)
+- [x] Kira Evans (Napari)
+- [x] Ross Barnowski (NumPy, NetworkX)
+- [x] Isabela Presedo-Floyd (Spyder, JupyterLab)
+- [x] Pamphile Roy (SciPy)
+
+### Scheduled
+
+- [ ] Inessa Pawson (NumPy)
+- [ ] Marianne Corvellec (scikit-image)
+- [ ] Hannah Aizenman (Matplotlib)
+
+### Pending
+
+- [ ] Jarrod Millman (NetworkX
+- [ ] Stéfan van der Walt (scikit-image, NetworkX)
+- [ ] Juanita Gómez (Scientific Python)
+- [ ] Noa Tamir (Pandas, Matplotlib)
+- [ ] Yuvi Panda (Jupyter)
+- [ ] Mridul Seth (NetworkX)
+- [ ] Matthias Bussonnier (IPython)
+- [ ] Andreas Mueller (scikit-learn)
+- [ ] Brigitta Sipőcz (Astropy)
+- [ ] Carol Willing (Python, Jupyter)
+
+## Success stories
+
+### Pending
+
+- [ ] Katie Bouman (Caltech)


### PR DESCRIPTION
When discussing with @jarrodmillman we agreed to have the list of interviews on GitHub to have an easy place to add more people to it. I've made a list of the interviews we already did with some other people from the community that I think we should interview, some of them I already talked to, some not but hopefully we can get these ones.

I'll try to update it periodically as I record the new interviews. Feel free to add new people at any time.