### PR TITLE
Update lighthouse

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,18 +4,3 @@
 
 [[plugins]]
   package = "netlify-plugin-checklinks"
-
-[[plugins]]
-  package = "@netlify/plugin-lighthouse"
-
-  # optional, fails build when a category is below a threshold
-  [plugins.inputs.thresholds]
-    performance = 0.85
-    accessibility = 0.90
-    best-practices = 0.95
-    seo = 0.95
-    pwa = 0.2
-
-  # optional, deploy the lighthouse report to a path under your site
-  [plugins.inputs]
-    output_path = "reports/lighthouse.html"


### PR DESCRIPTION
Addressing this:
```
8:28:16 AM: ❯ Loading plugins
8:28:16 AM:    - @netlify/plugin-lighthouse@2.1.3 from netlify.toml
8:28:16 AM:    - netlify-plugin-checklinks@4.1.1 from netlify.toml
8:28:16 AM: ​
8:28:16 AM: ❯ Outdated plugins
8:28:16 AM:    - @netlify/plugin-lighthouse@2.1.3: latest version is 4.1.1
8:28:16 AM:      To upgrade this plugin, please remove it from "netlify.toml" and install it from the Netlify plugins directory instead (https://app.netlify.com/plugins)
```

Unfortunately, I don't know how to keep lighthouse updated and specify its thresholds. I've had to do this for the other sites as well. It would be great, if someone figures out how to fix this.