### PR TITLE
chore: drop Python from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "monthly"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     allow:


### PR DESCRIPTION
There aren't any requirements.txt here, and IMO dependabot is pretty bad at keeping Python pins up to date (I think it's slowly getting better, but not great last I or SciPy tried it).

This keeps dependabot from compiling about not being able to find requirements.txt.