### PR TITLE
ci: fix bundler - Ruby mismatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ prepare:
 
 cookie_ruby_deps:
 	(cd external-content/cookie && \
-	gem install bundler && \
+	gem install bundler -v 2.4.22 && \
         bundle config set --local deployment 'true' && \
         bundle config set --local without development && \
 	bundle install)


### PR DESCRIPTION
Bundler seems to have dropped Ruby 2.3-2.7. This fixes the CI.