### PR TITLE
Link to the Scientific Python Lectures.

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -20,6 +20,14 @@ body = '''
 Learn recommended tools and approaches for developing Scientific Python libraries.
 '''
 
+[[item]]
+type = 'card'
+title = 'Lectures Notes'
+link = 'https://lectures.scientific-python.org'
+body = '''
+Numerical computing lectures that teach key packages in the scientific Python ecosystem, such as NumPy, SciPy, Matplotlib, scikit-learn, and scikit-image.
+'''
+
 {{< /grid >}}
 
 <!--


### PR DESCRIPTION
"learn" is linked from the front-page of scientific-python.org, so it may be natural for users to navigate there in the hope of finding lecture material.

Also, this should give more exposure to the lectures in a prominent place.