### PR TITLE
fix: trailing slash causes issues with the theme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ prepare:
 
 cookie:
 	(cd external-content/cookie/docs && \
-	BASE_URL=/development/ npx --yes mystmd build --html)
+	BASE_URL=/development npx --yes mystmd build --html)
 	mkdir -p public/development
 	cp -r external-content/cookie/docs/_build/html/. public/development/
 


### PR DESCRIPTION
This is causing the problem opening pages (https://github.com/jupyter-book/myst-theme/issues/910) that we've been seeing.
